### PR TITLE
Remove table from database before scraping

### DIFF
--- a/scraper.rb
+++ b/scraper.rb
@@ -233,7 +233,7 @@ end
 list = 'http://www.nigeriaembassyusa.org/index.php?page=state-governors'
 page = GovernorsList.new(response: Scraped::Request.new(url: list).response)
 
-ScraperWiki.sqliteexecute('DELETE FROM data') rescue nil
+ScraperWiki.sqliteexecute('DROP TABLE data') rescue nil
 page.governors.each do |governor|
   ScraperWiki.save_sqlite([:name], governor.to_h)
 end


### PR DESCRIPTION
SqliteMagic creates a unique index at CREATE TABLE time. This means that if the unique index arguments of ScraperWiki.save_sqlite change, we need to create a new table to ensure the db reflects the change. Part of: https://github.com/everypolitician/everypolitician/issues/593